### PR TITLE
chat-message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+public/uploads/*

--- a/Gemfile
+++ b/Gemfile
@@ -64,3 +64,5 @@ gem 'haml-rails', ">= 1.0", '<= 2.0.1'
 gem "font-awesome-sass"
 gem 'devise'
 gem 'pry-rails'
+gem 'carrierwave'
+gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,13 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    carrierwave (2.1.0)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      mimemagic (>= 0.3.0)
+      mini_mime (>= 0.1.3)
     childprocess (3.0.0)
     chromedriver-helper (2.1.1)
       archive-zip (~> 0.10)
@@ -105,6 +112,9 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
+    image_processing (1.10.3)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     io-like (0.3.1)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
@@ -121,6 +131,7 @@ GEM
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
     mimemagic (0.3.4)
+    mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
@@ -172,6 +183,8 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     ruby_dep (1.5.0)
     ruby_parser (3.14.2)
       sexp_processor (~> 4.9)
@@ -235,6 +248,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
   capybara (>= 2.15)
+  carrierwave
   chromedriver-helper
   coffee-rails (~> 4.2)
   devise
@@ -242,6 +256,7 @@ DEPENDENCIES
   haml-rails (>= 1.0, <= 2.0.1)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  mini_magick
   mysql2 (>= 0.4.4, < 0.6.0)
   pry-rails
   puma (~> 3.11)

--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -99,10 +99,6 @@
           &__list{
             display: flex;
           } 
-
-          &__name{
-            display: flex;
-          } 
         }
       }
       &__btn{
@@ -149,46 +145,49 @@
       }
     }
   }
+}
 
     .form {
       background-color: #d2d2d2;
       height: 90px;
-      padding: 20px 40px;
+      padding: 20px 50px 40px;
+      box-sizing: border-box;
+    }
+    
+    .new-message{
       display: flex;
+    }
+    .input-box {
+      width: calc(100% - 120px);
+      float: left;
+      height: 50px;
+      padding-left: 5px;
+    }
 
-      .input-box{
-        width: 100%;
-        display: flex;
-        position: relative;
+    .input-box-text{
+      float: left;
+      height: 50px;
+      color: #434a54;
+      border-style: none;
+      position: relative;
+    }
 
-          &__text{
-            height: 50px;
-            width: 100%;
-            color: #434a54;
-            border-style: none;
-            padding: 0 40px 0 10px;
-          }
+    .input-box__file {
+      display: none;
+    }
 
-          &__image{
-            position: absolute;
-            top: 10px;
-            right: 10px;
-            cursor: pointer;
-            font-size: 1.3rem;
-            
-            &__file{
-              display: none;
-            }
-          }
-        }
-          .submit-btn{
-            background-color: #38aef0;
-            color: white;
-            width: 100px;
-            height: 50px;
-            padding: 0 30px;
-            margin-left: 15px;
-            cursor: pointer;
-          }
-      }
+    .input-box__image {
+      line-height: 50px;
+      position: absolute;
+      right: 15px;
+    }
+    
+    .submit-btn{
+      background-color: #38aef0;
+      color: white;
+      height: 50px;
+      padding: 0 30px;
+      margin-left: 15px;
+      cursor: pointer;
+      float: right;
     }

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,8 +1,9 @@
 class GroupsController < ApplicationController
 
   def index
+    
   end
-  
+
   def new
     @group = Group.new
     @group.users << current_user
@@ -24,12 +25,12 @@ class GroupsController < ApplicationController
   def update
     @group = Group.find(params[:id])
     if @group.update(group_params)
-      redirect_to root_path, notice: 'グループを更新しました'
+      redirect_to group_messages_path(@group), notice: 'グループを更新しました'
     else
       render :edit
     end
   end
-
+  
   private
   def group_params
     params.require(:group).permit(:name, user_ids: [])

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,4 +1,29 @@
 class MessagesController < ApplicationController
+  before_action :set_group
+
   def index
+    @message = Message.new
+    @messages = @group.messages.includes(:user)
+  end
+
+  def create
+    @message = @group.messages.new(message_params)
+    if @message.save
+      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+    else
+      @messages = @group.messages.includes(:user)
+      flash.now[:alert] = 'メッセージを入力してください。'
+      render :index
+    end
+  end
+
+  private
+
+  def message_params
+    params.require(:message).permit(:content, :image).merge(user_id: current_user.id)
+  end
+
+  def set_group
+    @group = Group.find(params[:group_id])
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,20 @@
 class Group < ApplicationRecord
   has_many :group_users
   has_many :users, through: :group_users
+  has_many :messages
+
   validates :name, presence: true, uniqueness: true
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      if last_message.content?
+        last_message.content
+      else
+        '画像が投稿されています'
+      end
+    else
+      'まだメッセージはありません'
+    end
+  end
+
 end

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -2,3 +2,4 @@ class GroupUser < ApplicationRecord
   belongs_to :group
   belongs_to :user
 end
+

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,8 @@
+class Message < ApplicationRecord
+  belongs_to :group
+  belongs_to :user
+
+  validates :content, presence: true, unless: :image?
+
+  mount_uploader :image, ImageUploader
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,5 @@ class User < ApplicationRecord
 
   has_many :group_users
   has_many :groups, through: :group_users
+  has_many :messages
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,48 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+      process resize_to_fit: [800, 800]
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -1,14 +1,14 @@
 .main_chat
   .main_chat__header
     .main_chat__header__left
-      test
+      = @group.name
       .main_chat__header__left__member
         %ul.main_chat__header__left__member__list 
           Member ：
-          %li.main_chat__header__left__member__name masa
-    %a{:href => "edit"}
-      .main_chat__header__btn
-        Edit
+          %li.main_chat__header__left__member__name
+            - @group.users.each do |user|
+              = user.name
+    = link_to "Edit", edit_group_path(@group), class:'main_chat__header__btn'
   .main_chat__talk
     .main_chat__talk__post
       .main_chat__talk__post__info
@@ -17,12 +17,13 @@
         .main_chat__talk__post__info__date
           2020/02/23(Sun) 18:00:36
       .main_caht__talk__post__text
-        おはよう
+        = render @messages
 
   .form 
-    .input-box
-      %input{type: "text", class: "input-box__text",  placeholder: "type a message", name: "message[content]", id: "message_content"}
-      %label{class: "input-box__image"}
-        = icon('fas', 'image')
-        %input{type: "file", class: "input-box__image__file"}
-    %input{type: "submit", value: "Send", class: "submit-btn"}
+    = form_for [@group, @message] do |f|
+      = f.text_field :content, class: 'input-box', placeholder: 'type a message'
+      .input-box-text
+        = f.label :image, class: 'input-box__image' do
+          = icon('fas', 'image')
+          = f.file_field :image, class: 'input-box__file'
+      = f.submit 'Send', class: 'submit-btn'

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,0 +1,11 @@
+.message
+  .upper-message
+    .upper-message__user-name
+      = message.user.name
+    .upper-message__date
+      = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  .lower-message
+    - if message.content.present?
+      %p.lower-message__content
+        = message.content
+    = image_tag message.image.url, class: 'lower-message__image' if message.image.present?

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -11,8 +11,9 @@
   .side_bar__group
     - current_user.groups.each do |group|
       .side_bar__group__list
-        = link_to '#' do
+        = link_to group_messages_path(group) do
           .side_bar__group__list__name
             = group.name
           .side_bar__group__list__message
-            メッセージはまだありません
+            = group.show_last_message
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root 'groups#index'
   resources :users, only: [:edit, :update]
-  resources :groups, only: [:index, :new, :create, :edit, :update]
+  resources :groups, only: [:new, :create, :edit, :update] do
+    resources :messages, only: [:index, :create]
+  end
 end

--- a/db/migrate/20200225060553_create_messages.rb
+++ b/db/migrate/20200225060553_create_messages.rb
@@ -1,0 +1,11 @@
+class CreateMessages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :messages do |t|
+      t.string :content
+      t.string :image
+      t.references :group, foreign_key: true
+      t.references :user, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_24_120535) do
+ActiveRecord::Schema.define(version: 2020_02_25_060553) do
 
   create_table "group_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "group_id"
@@ -26,6 +26,17 @@ ActiveRecord::Schema.define(version: 2020_02_24_120535) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_groups_on_name", unique: true
+  end
+
+  create_table "messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "content"
+    t.string "image"
+    t.bigint "group_id"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_messages_on_group_id"
+    t.index ["user_id"], name: "index_messages_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -44,4 +55,6 @@ ActiveRecord::Schema.define(version: 2020_02_24_120535) do
 
   add_foreign_key "group_users", "groups"
   add_foreign_key "group_users", "users"
+  add_foreign_key "messages", "groups"
+  add_foreign_key "messages", "users"
 end

--- a/test/fixtures/messages.yml
+++ b/test/fixtures/messages.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class MessageTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#What
メッセージ機能の実装
モデルの作成
ルーティング設定
コントローラー定義
メッセージ送信機能の実装
投稿されたメッセージの実装
サイドバーにグループの最新チャット掲載
ヘッダーにグループ名ユーザー名の表示
グループ編集ページのリンク設置
グループ編集後のリダイレクト先設置
#Why
チャットを使えるようにする為
誰がどのメッセージを打ったか明確にする為
チャットを開かなくてもメッセージ状況を把握できるようにする為
グループを編集する為
グループ編集後にすぐ変更されたか確認できるようにする為